### PR TITLE
Add public groups creation logic (without advanced exceptions and tests)

### DIFF
--- a/force-app/main/default/classes/AddMembersToPublicGroups.cls
+++ b/force-app/main/default/classes/AddMembersToPublicGroups.cls
@@ -1,0 +1,44 @@
+/*
+* Class contains method that configure apex queueable job for create GroupMember object
+* records related to public groups defined in list of Group sObjects
+*/
+public without sharing class AddMembersToPublicGroups implements Queueable {
+    private List<Group> publicgroups;
+    /*
+    * @description class constructor that collect list of appropriate Group sObjects from CreatePublicGroups class
+    * and assign it to the publicgroups variable
+    * @param list of Group sObjects from CreatePublicGroups class
+    */
+    public AddMembersToPublicGroups(List<Group> publicgroups) {
+        this.publicgroups = publicgroups;
+        System.debug('AddMembersToPublicGroups Started...');
+    }
+    /*
+    * @description method that configure apex queueable job for create GroupMember object
+    * records related to public groups, based on list of Group sObjects from CreatePublicGroups class, 
+    * and catch the appropriate exception if inserting records was unsuccessful with displaying an appropriate debug message
+    * with description about an error.
+    * Also invoke sendMail method from EmailManager class that sends email notifications
+    * to the users who added to the appropriate public groups as group members.
+    * @param implements QueueableContext interface
+    */
+    public void execute(QueueableContext context) {
+        try {
+            List<GroupMember> groupmembers = new List<GroupMember>();
+                for (Group publicgroup : publicgroups) {
+                GroupMember gm = new GroupMember();
+                gm.GroupId = publicgroup.Id;
+                gm.UserOrGroupId = UserInfo.getUserId();
+                groupmembers.add(gm);
+                String useremail = UserInfo.getUserEmail();
+                EmailManager.sendMail(useremail, 'You have been added to public group ' + publicgroup.Name + 
+                '.', 'Congritulations, you have been added to public group ' + publicgroup.Name + 
+                ' as a group member.' + '\nFor more details, please contact your system administrator.');
+                }
+            insert groupmembers;
+
+        } catch (DmlException e) {
+            System.debug('An error has occurred while adding members to the public groups: ' + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/AddMembersToPublicGroups.cls-meta.xml
+++ b/force-app/main/default/classes/AddMembersToPublicGroups.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CreatePublicGroups.cls
+++ b/force-app/main/default/classes/CreatePublicGroups.cls
@@ -1,0 +1,42 @@
+/*
+* Class contains method that configure apex queueable job for create records 
+* in Group object, based on list of VoteCampaign__c sObjects from VoteCampaignTrigger
+*/
+public without sharing class CreatePublicGroups implements Queueable{
+    private List<VoteCampaign__c> votecampaignslist;
+    private Set<String> votecampaignsroles = new Set<String>{'Configurators', 'Moderators', 'Analysts', 'Voters'};
+    /*
+    * @description class constructor that collect list of VoteCampaign__c sObjects from VoteCampaignTrigger
+    * and assign it to the votecampaignlist variable
+    * @param list of VoteCampaign__c sObjects from VoteCampaignTrigger
+    */
+    public CreatePublicGroups(List<VoteCampaign__c> votecampaigns) {
+        this.votecampaignslist = votecampaigns;
+    }
+    /*
+    * @description method that configure apex queueable job for create records 
+    * in Group object, based on list of VoteCampaign__c sObjects from VoteCampaignTrigger.
+    * Also invoke apex queueble job for create GroupMember object records related to appropriate public groups
+    * Commented rows contains code for apex queueble job debugging
+    * @param implements QueueableContext interface
+    */
+    public void execute(QueueableContext context) {
+        List<Group> groupstocreate = new List<Group>();
+        for (VoteCampaign__c votecampaign : votecampaignslist) {
+            for (String role : votecampaignsroles) {
+                Group publicgroup = new Group();
+                publicgroup.Name = 'CMP-' + votecampaign.Name + '-' + role;
+                publicgroup.Type = 'Regular';
+                groupstocreate.add(publicgroup);
+            }
+        }
+        insert groupstocreate;
+        Map<Id,Group> groupsmap = new Map<Id, Group>(groupstocreate);
+        List<Id> groupsids = new List<Id>(groupsmap.keySet());
+        List<Group> groupstoaddmembers = [SELECT Id, Name, CreatedById FROM Group WHERE Id IN :groupsids AND Name LIKE '%Configurators'];
+        AddMembersToPublicGroups addmembersjob = new AddMembersToPublicGroups(groupstoaddmembers);
+        ID addmembersjobid = System.enqueueJob(addmembersjob);
+        //AsyncApexJob addmembersjob_log = [SELECT Id, Status, NumberOfErrors FROM AsyncApexJob WHERE Id = :addmembersjobid];
+        //System.debug('Add members job log: ' + addmembersjob_log);
+    }   
+}

--- a/force-app/main/default/classes/CreatePublicGroups.cls-meta.xml
+++ b/force-app/main/default/classes/CreatePublicGroups.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/EmailManager.cls
+++ b/force-app/main/default/classes/EmailManager.cls
@@ -1,0 +1,21 @@
+/*
+* Class contains method that invoke apex queueble job to send email notifications
+* to the users who added to the appropriate public groups as group members
+*/
+public without sharing class EmailManager {
+    /*
+    * @description method that invoke apex queueble job to send email notifications
+    * to the users who added to the appropriate public groups as group members
+    * @param(address) contains email address for the email notification message
+    * @param(subject) contains subject of the email notification message
+    * @param(body) contains body of the email notification message 
+    * Commented rows contains code for apex queueble job debugging
+    */
+    public static void sendMail (String address, String subject, String body) {
+        SendEmails sendemailsjob = new SendEmails(address, subject, body);
+        ID sendemailsjobid = System.enqueueJob(sendemailsjob);
+        // AsyncApexJob sendemailsjob_log = [SELECT Id, Status, NumberOfErrors FROM AsyncApexJob WHERE Id = :sendemailsjobid];
+        // System.debug('Add members job log: ' + sendemailsjob_log);
+    }
+
+}

--- a/force-app/main/default/classes/EmailManager.cls-meta.xml
+++ b/force-app/main/default/classes/EmailManager.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PublicGroupsManager.cls
+++ b/force-app/main/default/classes/PublicGroupsManager.cls
@@ -1,0 +1,23 @@
+/*
+* Class that manages actions with the Group object  (for instance - create public groups)
+*/
+public without sharing class PublicGroupsManager {
+    /*
+    * @description default class constructor with commented debug "start" message
+    */
+    public PublicGroupsManager() {
+        //System.debug('PublicGroupsManager started...');
+    }
+    /*
+    * @description method that invoke apex queueble job for create appropriate public groups.
+    * Commented rows contains code for apex queueble job debugging
+    * @param list of VoteCampaign__c sObjects
+    */
+    public static void createPublicGroups(List<VoteCampaign__c> newcampaigns) {
+        System.debug('createPublicGroups method started...');
+        CreatePublicGroups creategroupsjob = new CreatePublicGroups(newcampaigns);
+        ID creategroupsjobid = System.enqueueJob(creategroupsjob);
+        //AsyncApexJob creategroupsjob_log = [SELECT Id, Status, NumberOfErrors FROM AsyncApexJob WHERE Id = :creategroupsjobid];
+        //System.debug('Create groups job log: ' + creategroupsjob_log);
+    }
+}

--- a/force-app/main/default/classes/PublicGroupsManager.cls-meta.xml
+++ b/force-app/main/default/classes/PublicGroupsManager.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SendEmails.cls
+++ b/force-app/main/default/classes/SendEmails.cls
@@ -1,0 +1,45 @@
+/*
+* Class contains method that configure apex queueable job to send email notifications
+* to the users who added to the appropriate public groups as group members
+*/
+public without sharing class SendEmails implements Queueable {
+    private String address;
+    private String subject;
+    private String body;
+    /*
+    * @description class constructor that collect required information about email notification message
+    * and assign it to the appropriate variables 
+    * @param(address) contains email address for the email notification message
+    * @param(subject) contains subject of the email notification message
+    * @param(body) contains body of the email notification message 
+    */
+    public SendEmails(String address, String subject, String body) {
+        this.address = address;
+        this.subject = subject;
+        this.body = body;
+    }
+    /*
+    * @description method that configure apex queueable job to send email notifications
+    * to the users who added to the appropriate public groups as group members 
+    * and catch the appropriate error if sending email notification message was unsuccessful with displaying an appropriate debug message
+    * with description about an error.
+    * @param implements QueueableContext interface
+    */
+    public void execute (QueueableContext context) {
+        Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
+        String[] toAddresses = new String[] {address};
+        mail.setToAddresses(toAddresses);
+        mail.setSubject(subject);
+        mail.setPlainTextBody(body);
+        Messaging.SendEmailResult[] results = Messaging.sendEmail(
+                                 new Messaging.SingleEmailMessage[] { mail });
+        for (Messaging.SendEmailResult res : results) {
+            if (res.isSuccess()) {
+                System.debug('Email sent successfully');
+            }
+            else {
+                System.debug('The following errors occurred: ' + res.getErrors());                 
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/SendEmails.cls-meta.xml
+++ b/force-app/main/default/classes/SendEmails.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/VoteCampaignTriggerHandler.cls
+++ b/force-app/main/default/classes/VoteCampaignTriggerHandler.cls
@@ -1,0 +1,27 @@
+    /*
+    * This class implementing trigger handler to handle logic of the VoteCampaignTrigger.
+    */
+public without sharing class VoteCampaignTriggerHandler extends CustomMDTTriggerHandler {
+    public List<VoteCampaign__c> newcampaigns = new List<VoteCampaign__c>();
+    /*
+    * @description constructor that used for declare and assign list of VoteCampaigns__c sObjects (records)
+    * @param list of VoteCampaigns__c sObjects (records) which created after trigger activation
+    */
+    public VoteCampaignTriggerHandler(List<VoteCampaign__c> newcampaigns) {
+        this.newcampaigns = newcampaigns;
+        System.debug('VoteCampaignTriggerHandler started...');
+    }
+    /*
+    * @description constructor that used for catch list of VoteCampaigns__c sObjects (records) from VoteCampaignTrigger
+    */
+    public VoteCampaignTriggerHandler() {
+        this((List<VoteCampaign__c>)Trigger.new);
+    }
+    /*
+    * @description method that invoke public groups creation in case of trigger event afterInsert has occured,
+    and passes as an argument list of VoteCampaign__c sObjects
+    */
+    public override void afterInsert() {
+        PublicGroupsManager.createPublicGroups(newcampaigns);
+    }
+}

--- a/force-app/main/default/classes/VoteCampaignTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/VoteCampaignTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/triggers/VoteCampaignTrigger.trigger
+++ b/force-app/main/default/triggers/VoteCampaignTrigger.trigger
@@ -1,0 +1,7 @@
+/*
+* This trigger invoke the trigger handlers manager if VoteCampaign__c object record was inserted 
+* (trigger event - after insert)
+*/
+trigger VoteCampaignTrigger on VoteCampaign__c (after insert) {
+    new CustomMDTTriggerHandler().run();
+}

--- a/force-app/main/default/triggers/VoteCampaignTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/VoteCampaignTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>54.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
This feature automates (with Apex Trigger and TriggerHandler Framework) the process of creating the public groups and adding group members to them, after inserting a VoteCampaign__c object record.